### PR TITLE
prevents slice bounds out of range error

### DIFF
--- a/pkg/k8s/endpoint.go
+++ b/pkg/k8s/endpoint.go
@@ -49,12 +49,15 @@ func (m *Manager) updateEndpoints(targetServices []targetService) error {
 	}
 
 	//Delete old ports
-	for i, sub := range endpoint.Subsets {
+	updatedSubsets := endpoint.Subsets[:0]
+	for _, sub := range endpoint.Subsets {
 		if !subsetExistsInTargetServiceSlice(sub, targetServices) {
 			updated = true
-			endpoint.Subsets = append(endpoint.Subsets[:i], endpoint.Subsets[i+1:]...)
+			continue
 		}
+		updatedSubsets = append(updatedSubsets, sub)
 	}
+	endpoint.Subsets = updatedSubsets
 
 	if updated {
 		_, err = m.client.CoreV1().Endpoints(m.serviceNamespace).Update(endpoint)

--- a/pkg/k8s/loadbalancer.go
+++ b/pkg/k8s/loadbalancer.go
@@ -47,12 +47,15 @@ func (m *Manager) updateLBService(targetServices []targetService) error {
 	}
 
 	//Delete old ports
-	for i, sp := range service.Spec.Ports {
+	updatedPorts := service.Spec.Ports[:0]
+	for _, sp := range service.Spec.Ports {
 		if !servicePortExistsInTargetServiceSlice(sp, targetServices) {
 			updated = true
-			service.Spec.Ports = append(service.Spec.Ports[:i], service.Spec.Ports[i+1:]...)
+			continue
 		}
+		updatedPorts = append(updatedPorts, sp)
 	}
+	service.Spec.Ports = updatedPorts
 
 	if updated {
 		_, err = m.client.CoreV1().Services(m.serviceNamespace).Update(service)


### PR DESCRIPTION
The changes in this pull potentially fix a panic error observed in #817. I was unable to reproduce the issue locally. But just by looking at the source code I can see that the following line of code can cause a panic when `len(endpoint.Subsets) == 1`

`endpoint.Subsets = append(endpoint.Subsets[:i], endpoint.Subsets[i+1:]...)`

fixes https://github.com/kubermatic/kubermatic/issues/817